### PR TITLE
Fix typos method and parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.spdx</groupId>
   <artifactId>spdx-java-core</artifactId>
-  <version>1.0.0-RC1</version>
+  <version>1.0.0-RC2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>spdx-java-core</name>
   <description>Core libraries for SPDX</description>
@@ -38,13 +38,13 @@
     <url>https://github.com/spdx/spdx-java-core</url>
     <connection>scm:git:git://github.com/spdx/spdx-java-core.git</connection>
     <developerConnection>scm:git:git@github.com:spdx/spdx-java-core.git</developerConnection>
-    <tag>v1.0.0-RC1</tag>
+    <tag>HEAD</tag>
   </scm>
   <properties>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputTimestamp>1734153104</project.build.outputTimestamp>
+    <project.build.outputTimestamp>1734153119</project.build.outputTimestamp>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>spdx-1</sonar.organization>
     <sonar.projectKey>spdx-java-core</sonar.projectKey>

--- a/src/main/java/org/spdx/storage/IModelStore.java
+++ b/src/main/java/org/spdx/storage/IModelStore.java
@@ -17,7 +17,6 @@
  */
 package org.spdx.storage;
 
-import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/org/spdx/storage/IModelStore.java
+++ b/src/main/java/org/spdx/storage/IModelStore.java
@@ -17,6 +17,7 @@
  */
 package org.spdx.storage;
 
+import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -62,7 +63,7 @@ public interface IModelStore extends AutoCloseable {
 		SpdxId, 			// ID's that start with SpdxRef-
 		ListedLicense, 		// ID's associated with listed licenses
 		Anonymous, 			// ID's for object only referenced internally
-		Unknown				// ID's that just don't fit any pattern
+		Unkown				// ID's that just don't fit any pattern (supposed to be "Unknown")
 	}
 
 	/**
@@ -231,10 +232,22 @@ public interface IModelStore extends AutoCloseable {
     Optional<String> getCaseSensitiveId(String nameSpace, String caseInsensitiveId);
 
 	/**
+	 * Alias for getCaseSensitiveId
+	 * @param nameSpace the nameSpace used for the ID - the URI is formed by the nameSpace + "#" + caseInsensitiveId
+	 * @param caseInsensitiveId ID - case will be ignored
+	 * @return the case-sensitive ID if it exists
+	 * @deprecated As of release 1.0, replaced by {@link #getCaseSensitiveId(String, String)}
+	 */
+    @Deprecated default Optional<String> getCaseSensisitiveId(String nameSpace, String caseInsensitiveId) {
+		return getCaseSensitiveId(nameSpace, caseInsensitiveId);
+	}
+
+	/**
 	 * @param objectUri unique URI within the SPDX model store for the objects
 	 * @return type TypedValue containing the type of the ModelObject related to the ID
 	 */
     Optional<TypedValue> getTypedValue(String objectUri) throws InvalidSPDXAnalysisException;
+
 	/**
 	 * Deletes an item from the document
 	 * @param objectUri unique URI within the SPDX model store for the objects

--- a/src/main/java/org/spdx/storage/IModelStore.java
+++ b/src/main/java/org/spdx/storage/IModelStore.java
@@ -237,7 +237,8 @@ public interface IModelStore extends AutoCloseable {
 	 * @return the case-sensitive ID if it exists
 	 * @deprecated As of release 1.0, replaced by {@link #getCaseSensitiveId(String, String)}
 	 */
-    @Deprecated default Optional<String> getCaseSensisitiveId(String nameSpace, String caseInsensisitiveId) {
+	@Deprecated
+	default Optional<String> getCaseSensisitiveId(String nameSpace, String caseInsensisitiveId) {
 		return getCaseSensitiveId(nameSpace, caseInsensisitiveId);
 	}
 

--- a/src/main/java/org/spdx/storage/IModelStore.java
+++ b/src/main/java/org/spdx/storage/IModelStore.java
@@ -43,7 +43,7 @@ import org.spdx.core.TypedValue;
  *
  */
 public interface IModelStore extends AutoCloseable {
-	
+
 	interface IModelStoreLock {
 		void unlock();
 	}
@@ -52,7 +52,7 @@ public interface IModelStore extends AutoCloseable {
     interface ModelUpdate {
 		void apply() throws InvalidSPDXAnalysisException;
 	}
-	
+
 	/**
 	 * Different types of ID's
 	 */
@@ -62,7 +62,8 @@ public interface IModelStore extends AutoCloseable {
 		SpdxId, 			// ID's that start with SpdxRef-
 		ListedLicense, 		// ID's associated with listed licenses
 		Anonymous, 			// ID's for object only referenced internally
-		Unkown}				// ID's that just don't fit any pattern
+		Unknown				// ID's that just don't fit any pattern
+	}
 
 	/**
 	 * @param objectUri unique URI within the SPDX model store for the objects
@@ -223,11 +224,11 @@ public interface IModelStore extends AutoCloseable {
 	/**
 	 * In SPDX 2.2 license refs are allowed to be matched case-insensitive.  This function will return
 	 * the case-sensitive ID (e.g. if you have LicenseRef-ABC, calling this function with licenseref-abc will return LicenseRef-ABC
-	 * @param nameSpace the nameSpace used for the ID - the URI is formed by the nameSpace + "#" + caseInsensisitiveId
-	 * @param caseInsensisitiveId ID - case will be ignored
+	 * @param nameSpace the nameSpace used for the ID - the URI is formed by the nameSpace + "#" + caseInsensitiveId
+	 * @param caseInsensitiveId ID - case will be ignored
 	 * @return the case-sensitive ID if it exists
 	 */
-    Optional<String> getCaseSensisitiveId(String nameSpace, String caseInsensisitiveId);
+    Optional<String> getCaseSensitiveId(String nameSpace, String caseInsensitiveId);
 
 	/**
 	 * @param objectUri unique URI within the SPDX model store for the objects

--- a/src/main/java/org/spdx/storage/IModelStore.java
+++ b/src/main/java/org/spdx/storage/IModelStore.java
@@ -232,13 +232,13 @@ public interface IModelStore extends AutoCloseable {
 
 	/**
 	 * Alias for getCaseSensitiveId
-	 * @param nameSpace the nameSpace used for the ID - the URI is formed by the nameSpace + "#" + caseInsensitiveId
-	 * @param caseInsensitiveId ID - case will be ignored
+	 * @param nameSpace the nameSpace used for the ID - the URI is formed by the nameSpace + "#" + caseInsensisitiveId
+	 * @param caseInsensisitiveId ID - case will be ignored
 	 * @return the case-sensitive ID if it exists
 	 * @deprecated As of release 1.0, replaced by {@link #getCaseSensitiveId(String, String)}
 	 */
-    @Deprecated default Optional<String> getCaseSensisitiveId(String nameSpace, String caseInsensitiveId) {
-		return getCaseSensitiveId(nameSpace, caseInsensitiveId);
+    @Deprecated default Optional<String> getCaseSensisitiveId(String nameSpace, String caseInsensisitiveId) {
+		return getCaseSensitiveId(nameSpace, caseInsensisitiveId);
 	}
 
 	/**

--- a/src/main/java/org/spdx/storage/NullModelStore.java
+++ b/src/main/java/org/spdx/storage/NullModelStore.java
@@ -152,7 +152,7 @@ public class NullModelStore implements IModelStore {
 
 	@Override
 	public IdType getIdType(String objectUri) {
-		return IdType.Unknown;
+		return IdType.Unkown;
 	}
 
 	@Override

--- a/src/main/java/org/spdx/storage/NullModelStore.java
+++ b/src/main/java/org/spdx/storage/NullModelStore.java
@@ -152,12 +152,12 @@ public class NullModelStore implements IModelStore {
 
 	@Override
 	public IdType getIdType(String objectUri) {
-		return IdType.Unkown;
+		return IdType.Unknown;
 	}
 
 	@Override
-	public Optional<String> getCaseSensisitiveId(String nameSpace,
-			String caseInsensisitiveId) {
+	public Optional<String> getCaseSensitiveId(String nameSpace,
+			String caseInsensitiveId) {
 		return Optional.empty();
 	}
 

--- a/src/test/java/org/spdx/storage/MockModelStore.java
+++ b/src/test/java/org/spdx/storage/MockModelStore.java
@@ -194,8 +194,8 @@ public class MockModelStore implements IModelStore {
 	}
 
 	@Override
-	public Optional<String> getCaseSensisitiveId(String nameSpace,
-			String caseInsensisitiveId) {
+	public Optional<String> getCaseSensitiveId(String nameSpace,
+			String caseInsensitiveId) {
 		return Optional.empty();
 	}
 


### PR DESCRIPTION
- <s>enum: `Unkown` -> `Unknown`</s>
- method: `getCaseSensisitiveId` -> `getCaseSensitiveId`
  - parameter: `caseInsensisitiveId` -> `caseInsensitiveId`
- Add default method `getCaseSensisitiveId` with the same parameter spelling `caseInsensisitiveId` for backward compatibility
  - This [default method](https://docs.oracle.com/javase/tutorial/java/IandI/defaultmethods.html) is implemented inside the interface, so it will be available to any class implements the interface without the need to actually implemented it (to avoid breaking) 

<s>Note: as the enum and the method are public, this change will break any code that use any of them</s>

Method `getCaseSensisitiveId` is still available and can be called the same way.

Defer the renaming of enum for now, just add a comment to the code.