### PR TITLE
Replace deprecated Integer constructor w/ valueOf

### DIFF
--- a/src/test/java/org/spdx/core/TestCoreModelObject.java
+++ b/src/test/java/org/spdx/core/TestCoreModelObject.java
@@ -217,7 +217,7 @@ public class TestCoreModelObject {
 		assertTrue(c2.size() == cResult.size() && c2.containsAll(cResult) && cResult.containsAll(c2));
 		
 		modelType.setPropertyValue(INTEGER_PROPERTY_DESCRIPTOR, 15);
-		assertEquals(new Integer(15), modelType.getIntegerPropertyValue(INTEGER_PROPERTY_DESCRIPTOR).get());
+		assertEquals(Integer.valueOf(15), modelType.getIntegerPropertyValue(INTEGER_PROPERTY_DESCRIPTOR).get());
 		// Object property is tested in getPropertyValue tests
 	}
 


### PR DESCRIPTION
The Integer(int) constructor is deprecated in Java 9.

Note that the project targets Java 8 (1.8), so it is fine without changes.

The proposed code works with Java 8 and beyond.