### PR TITLE
Add API docs and SPDX spec links to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,23 @@
 Contributing
 ============
-Thank you for your interest in `java-spdx-core`. The project is open-source software, and bug reports, suggestions, and most especially patches are welcome.
+
+Thank you for your interest in `spdx-java-core`. The project is open-source software, and bug reports, suggestions, and most especially patches are welcome.
 
 Issues
 ------
-`java-spdx-core` has a [project page on GitHub](https://github.com/spdx/java-spdx-core) where you can [create an issue](https://github.com/spdx/java-spdx-core/issues/new/choose) to report a bug, make a suggestion, or propose a substantial change or improvement that you might like to make. You may also wish to contact the SPDX working group technical team through its mailing list, [spdx-tech@lists.spdx.org](mailto:spdx-tech@lists.spdx.org).
+
+`spdx-java-core` has a [project page on GitHub](https://github.com/spdx/spdx-java-core) where you can [create an issue](https://github.com/spdx/spdx-java-core/issues/new/choose) to report a bug, make a suggestion, or propose a substantial change or improvement that you might like to make. You may also wish to contact the SPDX working group technical team through its mailing list, [spdx-tech@lists.spdx.org](mailto:spdx-tech@lists.spdx.org).
 
 If you would like to work on a fix for any issue, please assign the issue to yourself prior to creating a Pull Request.
 
 Pull Requests
 -------
-The source code for `java-spdx-core` is hosted on [github.com/spdx/java-spdx-core](https://github.com/spdx/java-spdx-core). Please review [open pull requests](https://github.com/spdx/java-spdx-core/pulls) and [active branches](https://github.com/spdx/java-spdx-core/branches) before committing time to a substantial revision. Work along similar lines may already be in progress.
+
+The source code for `spdx-java-core` is hosted on [github.com/spdx/spdx-java-core](https://github.com/spdx/spdx-java-core). Please review [open pull requests](https://github.com/spdx/spdx-java-core/pulls) and [active branches](https://github.com/spdx/spdx-java-core/branches) before committing time to a substantial revision. Work along similar lines may already be in progress.
 
 To submit a pull request via GitHub, fork the repository, create a topic branch from `master` for your work, and send a pull request when ready. If you would prefer to send a patch or grant access to pull from your own Git repository, please contact the project's contributors by e-mail.
 
 Licensing
 ---------
+
 However you choose to contribute, please sign-off in each of your commits that you license your contributions under the terms of [the Developer Certificate of Origin](https://developercertificate.org/). Git has utilities for signing off on commits: `git commit -s` signs a current commit, and `git rebase --signoff <revision-range>` retroactively signs a range of past commits.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# java-spdx-core
+# spdx-java-core
 
-This repository is a component of the Java library which implements the Java object model for SPDX and provides useful helper functions.
+This repository is a component of the Java library which implements the Java object model for the [System Package Data Exchange (SPDX)](https://spdx.dev/) and provides useful helper functions.
 
 This repository contains core files used as a base and common to all model files.
+
+The API documentation is available at:
+<https://spdx.github.io/spdx-java-core/>
 
 Please refer to the [Spdx-Java-Library](https://github.com/spdx/spdx-java-Library) for information on how to use the code in this repository.
 
@@ -10,21 +13,17 @@ Contributions are welcome.  See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Code quality badges
 
-|   [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-java-core&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-java-core)    | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-java-core&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-java-core) | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-java-core&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-java-core) | [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-java-core&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-java-core) |
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-java-core&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-java-core) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-java-core&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-java-core) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-java-core&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-java-core) [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-java-core&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-java-core)
 
 ## Overall Architecture
 
-The primary class in the core library is the CoreModelObject.  All SPDX model classes inherit this class.  It contains several useful functions including the ability to compare to other CoreModelObjects, add/remove properties, and manage collections.
+The primary class in the core library is the [CoreModelObject](https://spdx.github.io/spdx-java-core/org/spdx/core/CoreModelObject.html).  All SPDX model classes inherit this class.  It contains several useful functions including the ability to compare to other CoreModelObjects, add/remove properties, and manage collections.
 
-Each major version of the SPDX specification should generate it's own set of classes which inherit from the CoreModelObject.
+Each major version of [the SPDX specification](https://spdx.org/specifications) should generate its own set of classes which inherit from the CoreModelObject.
 
 Below is a simplified class model diagram which includes example SPDX model versions:
 
-
-
-[![Simplified Class Diagram](ClassDiagram.drawio.png)]
-
-
+[![Simplified Class Diagram](ClassDiagram.drawio.png)](ClassDiagram.drawio.png)
 
 ## Development Status
 


### PR DESCRIPTION
- Add link to API doc at https://spdx.github.io/spdx-java-core/
- Add link to SPDX website/specification
- Update title ("java-spdx-core" -> "spdx-java-core") to match the Java package name and the current repo name
