### PR TITLE
Add 'isInitialized' method to DefaultModelStore

### DIFF
--- a/src/main/java/org/spdx/core/DefaultModelStore.java
+++ b/src/main/java/org/spdx/core/DefaultModelStore.java
@@ -42,6 +42,19 @@ public class DefaultModelStore {
 	private DefaultModelStore() {
 		// prevent instantiating class
 	}
+
+	/**
+	 * Checks if the default model store is initialized
+	 * @return true if the model store is initialized
+	 */
+	public static boolean isInitialized() {
+		lock.readLock().lock();
+		try {
+			return Objects.nonNull(defaultStore);
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
 	
 	/**
 	 * @return the default model store


### PR DESCRIPTION
This is required for the proposes initialization of the default model store in the SPDX Java Library