### PR TITLE
Fix bullets in CoreModelObject Javadoc

### DIFF
--- a/src/main/java/org/spdx/core/CoreModelObject.java
+++ b/src/main/java/org/spdx/core/CoreModelObject.java
@@ -52,20 +52,24 @@ import org.spdx.storage.IModelStore.ModelUpdate;
  * is passed as a parameter.
  * <p>
  * There are 2 methods of setting values:
- *   - call the setPropertyValue, clearValueCollection or addValueToCollection methods - this will call the modelStore and store the
- *     value immediately
- *   - Gather a list of updates by calling the updatePropertyValue, updateClearValueList, or updateAddPropertyValue
+ * <ul>
+ *   <li>Call the setPropertyValue, clearValueCollection or addValueToCollection methods.
+ *     This will call the modelStore and store the value immediately.</li>
+ *   <li>Gather a list of updates by calling the updatePropertyValue, updateClearValueList, or updateAddPropertyValue
  *     methods.  These methods return a ModelUpdate which can be applied later by calling the <code>apply()</code> method.
  *     A convenience method <code>Write.applyUpdatesInOneTransaction</code> will perform all updates within
  *     a single transaction. This method may result in higher performance updates for some Model Store implementations.
  *     Note that none of the updates will be applied until the storage manager update method is invoked.
+ *   </li>
+ * </ul>
  * <p>
  * Property values are restricted to the following types:
- *   - String - Java Strings
- *   - Boolean - Java Boolean or primitive boolean types
- *   - CoreModelObject - A concrete subclass of this type
- *   - {@literal Collection<T>} - A Collection of type T where T is one of the supported non-collection types
- * <p>
+ * <ul>
+ *   <li>String - Java Strings</li>
+ *   <li>Boolean - Java Boolean or primitive boolean types</li>
+ *   <li>CoreModelObject - A concrete subclass of this type</li>
+ *   <li>{@literal Collection<T>} - A Collection of type T where T is one of the supported non-collection types</li>
+ * </ul>
  * This class also handles the conversion of a CoreModelObject to and from a TypeValue for storage in the ModelStore.
  *
  * @author Gary O'Neall
@@ -107,7 +111,7 @@ public abstract class CoreModelObject {
 	/**
 	 * Open or create a model object with the default store
 	 * @param objectUri Anonymous ID or URI for the model object
-	 * @param specVersion - version of the SPDX spec the object complies with
+	 * @param specVersion Version of the SPDX spec the object complies with
 	 * @throws InvalidSPDXAnalysisException on any SPDX related exception
 	 */
 	protected CoreModelObject(String objectUri, String specVersion) throws InvalidSPDXAnalysisException {

--- a/src/main/java/org/spdx/core/CoreModelObject.java
+++ b/src/main/java/org/spdx/core/CoreModelObject.java
@@ -70,6 +70,7 @@ import org.spdx.storage.IModelStore.ModelUpdate;
  *   <li>CoreModelObject - A concrete subclass of this type</li>
  *   <li>{@literal Collection<T>} - A Collection of type T where T is one of the supported non-collection types</li>
  * </ul>
+ * <p>
  * This class also handles the conversion of a CoreModelObject to and from a TypeValue for storage in the ModelStore.
  *
  * @author Gary O'Neall

--- a/src/main/java/org/spdx/core/CoreModelObject.java
+++ b/src/main/java/org/spdx/core/CoreModelObject.java
@@ -102,7 +102,7 @@ public abstract class CoreModelObject {
 		
 	/**
 	 * Create a new Model Object using an Anonymous ID with the default store and default document URI
-	 * @param specVersion - version of the SPDX spec the object complies with
+	 * @param specVersion version of the SPDX spec the object complies with
 	 * @throws InvalidSPDXAnalysisException on any SPDX related exception
 	 */
 	protected CoreModelObject(String specVersion) throws InvalidSPDXAnalysisException {
@@ -185,7 +185,7 @@ public abstract class CoreModelObject {
 
 	/**
 	 * @param builder base builder to create the CoreModelObject from
-	 * @param specVersion - version of the SPDX spec the object complies with
+	 * @param specVersion version of the SPDX spec the object complies with
 	 * @throws InvalidSPDXAnalysisException on any SPDX related exception
 	 */
 	protected CoreModelObject(CoreModelObjectBuilder builder, String specVersion) throws InvalidSPDXAnalysisException {

--- a/src/main/java/org/spdx/core/ModelObjectHelper.java
+++ b/src/main/java/org/spdx/core/ModelObjectHelper.java
@@ -48,7 +48,7 @@ public class ModelObjectHelper {
 	 * @param objectUri the Object URI or anonymous ID
 	 * @param propertyDescriptor property descriptor for the property
 	 * @param copyManager if non null, any ModelObject property value not stored in the modelStore under the stDocumentUri will be copied to make it available
-	 * @param specVersion - version of the SPDX spec the object complies with
+	 * @param specVersion version of the SPDX spec the object complies with
 	 * @param type optional type hint - used for individuals where the type may be ambiguous
 	 * @param idPrefix prefix to be used when generating new SPDX IDs
 	 * @return value associated with a property
@@ -184,7 +184,7 @@ public class ModelObjectHelper {
 	 * @param modelStore  ModelStore to use in fetching or creating
 	 * @param copyManager   if not null, copy any referenced ID's outside of this
 	 *                      document/model store
-	 * @param specVersion - version of the SPDX spec the object complies with
+	 * @param specVersion version of the SPDX spec the object complies with
 	 * @param type optional type hint - used for individuals where the type may be ambiguous
 	 * @param idPrefix Prefix to be used if any new object URI's are generated
 	 * @return the object itself unless it is a TypedValue, in which case a
@@ -250,7 +250,7 @@ public class ModelObjectHelper {
 	 * @param modelStore  ModelStore to use in fetching or creating
 	 * @param copyManager if not null, copy any referenced ID's outside of this
 	 *                    document/model store
-	 * @param specVersion - version of the SPDX spec the object complies with
+	 * @param specVersion version of the SPDX spec the object complies with
 	 * @param type optional type hint - used for individuals where the type may be ambiguous
 	 * @param idPrefix Prefix to be used if any new object URI's are generated
 	 * @return the object itself unless it is a TypedValue, in which case a

--- a/src/main/java/org/spdx/core/ModelSet.java
+++ b/src/main/java/org/spdx/core/ModelSet.java
@@ -47,7 +47,7 @@ public class ModelSet<T extends Object> extends ModelCollection<Object> implemen
 	 * @param propertyDescriptor descriptor for the property use for the model collections
 	 * @param copyManager if non-null, use this to copy properties when referenced outside this model store
 	 * @param type The class of the elements to be stored in the collection if none, null if not known
-	 * @param specVersion - version of the SPDX spec the object complies with
+	 * @param specVersion version of the SPDX spec the object complies with
 	 * @param idPrefix prefix to be used when generating new SPDX IDs
 	 * @throws InvalidSPDXAnalysisException on parsing or store errors
 	 */

--- a/src/main/java/org/spdx/core/NotEquivalentReason.java
+++ b/src/main/java/org/spdx/core/NotEquivalentReason.java
@@ -28,24 +28,57 @@ import org.spdx.storage.PropertyDescriptor;
  * @author Gary O'Neall
  */
 public class NotEquivalentReason {
-	
+
+	/**
+	 * Enum representing the reasons why two model objects are not equivalent.
+	 */
 	public enum NotEquivalent {
-		DIFFERENT_CLASS, MISSING_PROPERTY, PROPERTY_NOT_EQUIVALENT, COMPARE_PROPERTY_MISSING}
-		
+		/**
+		 * Indicates that the objects are of different classes.
+		 */
+		DIFFERENT_CLASS,
+
+		/**
+		 * Indicates that a property is missing in one of the objects.
+		 */
+		MISSING_PROPERTY,
+
+		/**
+		 * Indicates that a property value is not equivalent between the objects.
+		 */
+		PROPERTY_NOT_EQUIVALENT,
+
+		/**
+		 * Indicates that a property to compare is missing.
+		 */
+		COMPARE_PROPERTY_MISSING
+	}
+
 		NotEquivalent reason;
 		PropertyDescriptor property = null;
-		
+
+		/**
+		 * Constructs a NotEquivalentReason with the specified reason.
+		 * 
+		 * @param reason the reason why the objects are not equivalent
+		 */
 		public NotEquivalentReason(NotEquivalent reason) {
 			this.reason = reason;
 		}
-		
+
+		/**
+		 * Constructs a NotEquivalentReason with the specified reason and property.
+		 * 
+		 * @param reason the reason why the objects are not equivalent
+		 * @param property the property descriptor associated with the reason
+		 */
 		public NotEquivalentReason(NotEquivalent reason, PropertyDescriptor property) {
 			this(reason);
 			this.property = property;
 		}
 
 		/**
-		 * @return the reason
+		 * @return the reason why the objects are not equivalent
 		 */
 		public NotEquivalent getReason() {
 			return reason;

--- a/src/main/java/org/spdx/core/SpdxCoreConstants.java
+++ b/src/main/java/org/spdx/core/SpdxCoreConstants.java
@@ -11,14 +11,33 @@ package org.spdx.core;
  */
 public class SpdxCoreConstants {
 
+	/**
+	 * Enumeration representing the major versions of the SPDX specification
+	 */
 	@SuppressWarnings("unused")
     public enum SpdxMajorVersion {
+		/**
+		 * SPDX version 1.x
+		 */
 		VERSION_1("SPDX-1."),
+
+		/**
+		 * SPDX version 2.x
+		 */
 		VERSION_2("SPDX-2."),
+
+		/**
+		 * SPDX version 3.x
+		 */
 		VERSION_3("3.");
 
 		private final String prefix;
-		
+
+		/**
+		 * Returns the latest major version of the SPDX specification.
+		 *
+		 * @return the latest major version
+		 */
 		public static SpdxMajorVersion latestVersion() {
 			return VERSION_3;
 		}
@@ -35,10 +54,17 @@ public class SpdxCoreConstants {
 		}
 	}
 
-		// SPDX Listed License constants
+	/**
+	 * The URL for the SPDX Listed Licenses.
+ 	 */
 	public static final String LISTED_LICENSE_URL = "https://spdx.org/licenses/";
-	// http rather than https since RDF depends on the exact string, 
-	// we were not able to update the namespace variable to match the URL's.
+
+	/**
+	 * The namespace prefix for the SPDX Listed Licenses.
+	 * <p>
+	 * Note: This uses "http" rather than "https" since RDF depends on the exact string,
+	 * and we were not able to update the namespace variable to match the URL's.
+	 */
 	public static final String LISTED_LICENSE_NAMESPACE_PREFIX = "http://spdx.org/licenses/";
 
 }

--- a/src/main/java/org/spdx/core/TypedValue.java
+++ b/src/main/java/org/spdx/core/TypedValue.java
@@ -11,6 +11,8 @@ public class TypedValue {
 	String specVersion;
 	
 	/**
+	 * Constructs a TypedValue with the specified object URI, type, and spec version.
+	 * 
 	 * @param objectUri URI or anon ID for the object
 	 * @param type a string representation of the type of the object
 	 * @param specVersion version of the spec

--- a/src/main/java/org/spdx/licenseTemplate/LicenseTemplateRule.java
+++ b/src/main/java/org/spdx/licenseTemplate/LicenseTemplateRule.java
@@ -48,9 +48,9 @@ public class LicenseTemplateRule {
 	/**
 	 * Create a new LicenseTemplateRule
 	 * @param name Name of the rule - must not be null
-	 * @param type - type of rule
-	 * @param original - Original text - must not be null
-	 * @param example - Example text - may be null
+	 * @param type Type of rule
+	 * @param original Original text - must not be null
+	 * @param example Example text - may be null
 	 * @throws LicenseTemplateRuleException if the license template could not be parsed
 	 */
 	public LicenseTemplateRule(String name, RuleType type, String original, String match, String example) throws LicenseTemplateRuleException {


### PR DESCRIPTION
- Add `<ul>` `<li>` HTML markups to CoreModelObject so the bullet lists display properly in the API doc
- Also add descriptions to NotEquivalent Enums and TypedValue constructor.

See screenshot comparisons below.

Demo: https://bact.github.io/spdx-java-core/

--

CoreModelObject unformatted:
![CoreModelObject unformatted](https://github.com/user-attachments/assets/003c41db-c390-49bb-84aa-bae3dfce1c32)

CoreModelObject formatted:
![CoreModelObject formatted](https://github.com/user-attachments/assets/6c9d4502-512b-4e01-a3d3-9a8639c904d5)

--

Enum without descriptions:
![Enum without descriptions](https://github.com/user-attachments/assets/01d8ce40-9354-4f4f-9d98-d3473299d300)

Enum with descriptions:
![Enum with descriptions](https://github.com/user-attachments/assets/f3af13c1-a710-432f-a179-272457a1699d)
