### PR TITLE
Update SPDX headers in source files

### DIFF
--- a/src/main/java/org/spdx/core/CoreModelObject.java
+++ b/src/main/java/org/spdx/core/CoreModelObject.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2023 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/DefaultModelStore.java
+++ b/src/main/java/org/spdx/core/DefaultModelStore.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/DefaultStoreNotInitializedException.java
+++ b/src/main/java/org/spdx/core/DefaultStoreNotInitializedException.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/DuplicateSpdxIdException.java
+++ b/src/main/java/org/spdx/core/DuplicateSpdxIdException.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/IExternalElementInfo.java
+++ b/src/main/java/org/spdx/core/IExternalElementInfo.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/IModelCopyManager.java
+++ b/src/main/java/org/spdx/core/IModelCopyManager.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/ISpdxModelInfo.java
+++ b/src/main/java/org/spdx/core/ISpdxModelInfo.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/IndividualUriValue.java
+++ b/src/main/java/org/spdx/core/IndividualUriValue.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/InvalidSPDXAnalysisException.java
+++ b/src/main/java/org/spdx/core/InvalidSPDXAnalysisException.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/InvalidSpdxPropertyException.java
+++ b/src/main/java/org/spdx/core/InvalidSpdxPropertyException.java
@@ -1,20 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- *
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/ModelCollection.java
+++ b/src/main/java/org/spdx/core/ModelCollection.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2023 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/ModelObjectHelper.java
+++ b/src/main/java/org/spdx/core/ModelObjectHelper.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2023 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/ModelRegistry.java
+++ b/src/main/java/org/spdx/core/ModelRegistry.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/ModelRegistryException.java
+++ b/src/main/java/org/spdx/core/ModelRegistryException.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/ModelSet.java
+++ b/src/main/java/org/spdx/core/ModelSet.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/NotEquivalentReason.java
+++ b/src/main/java/org/spdx/core/NotEquivalentReason.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2023 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/RuntimeSpdxException.java
+++ b/src/main/java/org/spdx/core/RuntimeSpdxException.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
@@ -8,7 +9,6 @@ package org.spdx.core;
  * Runtime Exception wrapper for SPDX exceptions (cause field)
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("unused")
 public class RuntimeSpdxException extends RuntimeException {

--- a/src/main/java/org/spdx/core/SimpleUriValue.java
+++ b/src/main/java/org/spdx/core/SimpleUriValue.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/SpdxCoreConstants.java
+++ b/src/main/java/org/spdx/core/SpdxCoreConstants.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/SpdxIdInUseException.java
+++ b/src/main/java/org/spdx/core/SpdxIdInUseException.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 
@@ -21,7 +9,6 @@ package org.spdx.core;
  * Exception when an SPDX element is in use (e.g. exception thrown when attempting to delete)
  * 
  * @author Gary O'Neall
- *
  */
 @SuppressWarnings("unused")
 public class SpdxIdInUseException extends InvalidSPDXAnalysisException {

--- a/src/main/java/org/spdx/core/SpdxIdNotFoundException.java
+++ b/src/main/java/org/spdx/core/SpdxIdNotFoundException.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/SpdxInvalidIdException.java
+++ b/src/main/java/org/spdx/core/SpdxInvalidIdException.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/SpdxInvalidTypeException.java
+++ b/src/main/java/org/spdx/core/SpdxInvalidTypeException.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/SpdxObjectNotInStoreException.java
+++ b/src/main/java/org/spdx/core/SpdxObjectNotInStoreException.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.core;
 

--- a/src/main/java/org/spdx/core/TypedValue.java
+++ b/src/main/java/org/spdx/core/TypedValue.java
@@ -1,5 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.core;
-
 
 /**
  * Value which is a stored typed item

--- a/src/main/java/org/spdx/core/package-info.java
+++ b/src/main/java/org/spdx/core/package-info.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 /**
  * Common classes used by the SPDX model and library

--- a/src/main/java/org/spdx/licenseTemplate/HtmlTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/licenseTemplate/HtmlTemplateOutputHandler.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 /**

--- a/src/main/java/org/spdx/licenseTemplate/ILicenseTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/licenseTemplate/ILicenseTemplateOutputHandler.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 /**

--- a/src/main/java/org/spdx/licenseTemplate/InvalidLicenseTemplateException.java
+++ b/src/main/java/org/spdx/licenseTemplate/InvalidLicenseTemplateException.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2016 Source Auditor Inc.
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2016 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 /**

--- a/src/main/java/org/spdx/licenseTemplate/LicenseParserException.java
+++ b/src/main/java/org/spdx/licenseTemplate/LicenseParserException.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2015 Source Auditor Inc.
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2015 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 import org.spdx.core.InvalidSPDXAnalysisException;

--- a/src/main/java/org/spdx/licenseTemplate/LicenseTemplateRule.java
+++ b/src/main/java/org/spdx/licenseTemplate/LicenseTemplateRule.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 import java.util.regex.Matcher;

--- a/src/main/java/org/spdx/licenseTemplate/LicenseTemplateRuleException.java
+++ b/src/main/java/org/spdx/licenseTemplate/LicenseTemplateRuleException.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 /**

--- a/src/main/java/org/spdx/licenseTemplate/LicenseTextHelper.java
+++ b/src/main/java/org/spdx/licenseTemplate/LicenseTextHelper.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.licenseTemplate;
 

--- a/src/main/java/org/spdx/licenseTemplate/LineColumn.java
+++ b/src/main/java/org/spdx/licenseTemplate/LineColumn.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.licenseTemplate;
 

--- a/src/main/java/org/spdx/licenseTemplate/SpdxLicenseTemplateHelper.java
+++ b/src/main/java/org/spdx/licenseTemplate/SpdxLicenseTemplateHelper.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 import java.util.regex.Matcher;
@@ -27,7 +16,6 @@ import org.jsoup.nodes.Document;
  * Implements common conversion methods for processing SPDX license templates
  * 
  * @author Gary O'Neall
- *
  */
 public class SpdxLicenseTemplateHelper {
 

--- a/src/main/java/org/spdx/licenseTemplate/TextTemplateOutputHandler.java
+++ b/src/main/java/org/spdx/licenseTemplate/TextTemplateOutputHandler.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 /**

--- a/src/main/java/org/spdx/licenseTemplate/package-info.java
+++ b/src/main/java/org/spdx/licenseTemplate/package-info.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * 
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 /**
  * License template are used for matching licenses

--- a/src/main/java/org/spdx/storage/IModelStore.java
+++ b/src/main/java/org/spdx/storage/IModelStore.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.storage;
 

--- a/src/main/java/org/spdx/storage/ISerializableModelStore.java
+++ b/src/main/java/org/spdx/storage/ISerializableModelStore.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.storage;
 

--- a/src/main/java/org/spdx/storage/NullModelStore.java
+++ b/src/main/java/org/spdx/storage/NullModelStore.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.storage;
 

--- a/src/main/java/org/spdx/storage/PropertyDescriptor.java
+++ b/src/main/java/org/spdx/storage/PropertyDescriptor.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2023 Source Auditor Inc.
- * <p>
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- * <p>
- *       http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 package org.spdx.storage;
 

--- a/src/main/java/org/spdx/storage/package-info.java
+++ b/src/main/java/org/spdx/storage/package-info.java
@@ -1,19 +1,7 @@
 /**
- * Copyright (c) 2019 Source Auditor Inc.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2019 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * 
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 /**
  * Classes that implement the storage interfaces for reading and writing 

--- a/src/test/java/org/spdx/core/MockCopyManager.java
+++ b/src/test/java/org/spdx/core/MockCopyManager.java
@@ -1,16 +1,16 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
 import org.spdx.storage.IModelStore;
 
 /**
- * @author Gary O'Neall
- * 
- * Copy manager for testing
+ * Mock copy manager for testing
  *
+ * @author Gary O'Neall
  */
 public class MockCopyManager implements IModelCopyManager {
 

--- a/src/test/java/org/spdx/core/MockEnum.java
+++ b/src/test/java/org/spdx/core/MockEnum.java
@@ -1,14 +1,14 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
 /**
- * @author Gary O'Neall
- * 
- * Enum for testing
+ * Mock enum for testing
  *
+ * @author Gary O'Neall
  */
 public enum MockEnum implements IndividualUriValue {
 	

--- a/src/test/java/org/spdx/core/MockIndividual.java
+++ b/src/test/java/org/spdx/core/MockIndividual.java
@@ -1,12 +1,14 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
 /**
- * @author Gary O'Neall
+ * Mock individual for testing
  *
+ * @author Gary O'Neall
  */
 public class MockIndividual implements IndividualUriValue {
 	

--- a/src/test/java/org/spdx/core/MockModelInfo.java
+++ b/src/test/java/org/spdx/core/MockModelInfo.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
@@ -14,8 +15,9 @@ import javax.annotation.Nullable;
 import org.spdx.storage.IModelStore;
 
 /**
- * @author Gary O'Neall
+ * Mock model information for testing
  *
+ * @author Gary O'Neall
  */
 public class MockModelInfo implements ISpdxModelInfo {
 	

--- a/src/test/java/org/spdx/core/MockModelType.java
+++ b/src/test/java/org/spdx/core/MockModelType.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
@@ -13,10 +14,9 @@ import org.spdx.storage.IModelStore;
 import org.spdx.storage.PropertyDescriptor;
 
 /**
- * @author Gary
- * 
  * Mock model type for testing
  *
+ * @author Gary O'Neall
  */
 public class MockModelType extends CoreModelObject {
 	

--- a/src/test/java/org/spdx/core/TestCoreModelObject.java
+++ b/src/test/java/org/spdx/core/TestCoreModelObject.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
@@ -21,7 +22,6 @@ import org.spdx.storage.PropertyDescriptor;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class TestCoreModelObject {
 

--- a/src/test/java/org/spdx/core/TestModelCollection.java
+++ b/src/test/java/org/spdx/core/TestModelCollection.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
@@ -16,8 +17,9 @@ import org.spdx.storage.MockModelStore;
 import org.spdx.storage.PropertyDescriptor;
 
 /**
- * @author Gary O'Neall
+ * Test core model object
  *
+ * @author Gary O'Neall
  */
 public class TestModelCollection {
 	

--- a/src/test/java/org/spdx/core/TestModelObjectHelper.java
+++ b/src/test/java/org/spdx/core/TestModelObjectHelper.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
@@ -18,8 +19,9 @@ import org.spdx.storage.MockModelStore;
 import org.spdx.storage.PropertyDescriptor;
 
 /**
- * @author Gary O'Neall
+ * Test model object helper
  *
+ * @author Gary O'Neall
  */
 public class TestModelObjectHelper {
 	

--- a/src/test/java/org/spdx/core/TestModelRegistry.java
+++ b/src/test/java/org/spdx/core/TestModelRegistry.java
@@ -1,4 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.core;
+
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
@@ -13,14 +19,10 @@ import org.junit.Test;
 import org.spdx.storage.IModelStore;
 import org.spdx.storage.MockModelStore;
 
-/*
- * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
- */
-
 /**
- * @author Gary O'Neall
+ * Test model registry
  *
+ * @author Gary O'Neall
  */
 public class TestModelRegistry {
 	

--- a/src/test/java/org/spdx/core/TestModelSet.java
+++ b/src/test/java/org/spdx/core/TestModelSet.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
@@ -15,8 +16,9 @@ import org.spdx.storage.MockModelStore;
 import org.spdx.storage.PropertyDescriptor;
 
 /**
- * @author Gary O'Neall
+ * Test model set
  *
+ * @author Gary O'Neall
  */
 public class TestModelSet {
 	

--- a/src/test/java/org/spdx/core/TestSimpleUriValue.java
+++ b/src/test/java/org/spdx/core/TestSimpleUriValue.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.core;
 
@@ -11,8 +12,9 @@ import org.junit.Test;
 import org.spdx.storage.MockModelStore;
 
 /**
- * @author Gary O'Neall
+ * Test Simple URI value
  *
+ * @author Gary O'Neall
  */
 public class TestSimpleUriValue {
 	

--- a/src/test/java/org/spdx/licenseTemplate/LicenseTextHelperTest.java
+++ b/src/test/java/org/spdx/licenseTemplate/LicenseTextHelperTest.java
@@ -1,20 +1,9 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- * Copyright (c) 2013 Black Duck Software Inc.
- * 
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Black Duck Software Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 
@@ -24,13 +13,11 @@ import java.util.Map;
 import junit.framework.TestCase;
 
 /**
- * @author Gary O'Neall
+ * Test license text helper
  *
+ * @author Gary O'Neall
  */
 public class LicenseTextHelperTest extends TestCase {
-	
-
-    
 
 	/**
 	 * @throws java.lang.Exception
@@ -234,7 +221,7 @@ public class LicenseTextHelperTest extends TestCase {
 		assertEquals("m", result[3]);
 		assertEquals("corporation", result[4]);
 		assertEquals("2002", result[5]);
-		test = "Claims      If";
+		test = "Claims     If";
 		result = LicenseTextHelper.tokenizeLicenseText(test, tokenToLocation);
 		assertEquals(2, result.length);
 		assertEquals("claims",result[0]);

--- a/src/test/java/org/spdx/licenseTemplate/TestHtmlTemplateOutputHandler.java
+++ b/src/test/java/org/spdx/licenseTemplate/TestHtmlTemplateOutputHandler.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 import static org.junit.Assert.*;
@@ -22,8 +11,9 @@ import org.junit.Test;
 import org.spdx.licenseTemplate.LicenseTemplateRule.RuleType;
 
 /**
- * @author Source Auditor
+ * Test HTML template output handler
  *
+ * @author Source Auditor
  */
 public class TestHtmlTemplateOutputHandler {
 

--- a/src/test/java/org/spdx/licenseTemplate/TestLicenseTemplateRule.java
+++ b/src/test/java/org/spdx/licenseTemplate/TestLicenseTemplateRule.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 import static org.junit.Assert.*;
@@ -22,8 +11,9 @@ import org.junit.Test;
 import org.spdx.licenseTemplate.LicenseTemplateRule.RuleType;
 
 /**
- * @author Source Auditor
+ * Test license template rule
  *
+ * @author Source Auditor
  */
 public class TestLicenseTemplateRule {
 

--- a/src/test/java/org/spdx/licenseTemplate/TestSpdxLicenseTemplateHelper.java
+++ b/src/test/java/org/spdx/licenseTemplate/TestSpdxLicenseTemplateHelper.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 import static org.junit.Assert.*;
@@ -22,8 +11,9 @@ import org.junit.Test;
 import org.spdx.licenseTemplate.LicenseTemplateRule.RuleType;
 
 /**
- * @author Gary O'Neall
+ * Test SPDX license template helper
  *
+ * @author Gary O'Neall
  */
 public class TestSpdxLicenseTemplateHelper {
 

--- a/src/test/java/org/spdx/licenseTemplate/TestTextTemplateOutputHandler.java
+++ b/src/test/java/org/spdx/licenseTemplate/TestTextTemplateOutputHandler.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.licenseTemplate;
 
 import static org.junit.Assert.*;
@@ -22,8 +11,9 @@ import org.junit.Test;
 import org.spdx.licenseTemplate.LicenseTemplateRule.RuleType;
 
 /**
- * @author Source Auditor
+ * Test text template output handler
  *
+ * @author Source Auditor
  */
 public class TestTextTemplateOutputHandler {
 

--- a/src/test/java/org/spdx/storage/MockModelStore.java
+++ b/src/test/java/org/spdx/storage/MockModelStore.java
@@ -1,6 +1,7 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) 2024 Source Auditor Inc.
  */
 package org.spdx.storage;
 
@@ -19,10 +20,9 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.core.TypedValue;
 
 /**
- * @author Gary
- * 
  * Mock model store for testing
  *
+ * @author Gary O'Neall
  */
 public class MockModelStore implements IModelStore {
 	


### PR DESCRIPTION
- Put copyright texts to `SPDX-FileCopyrightText`:
  - For example: `Copyright (c) 2023 Source Auditor Inc.` -> `SPDX-FileCopyrightText: Copyright (c) 2023 Source Auditor Inc.`
- Add `SPDX-FileType: SOURCE`
- Follow header pattern since 2024 that do not include the content of the license
- These should allow better parsing of copyright information and file type, also reduce the size of source files a bit
- Add missing copyright header - using this template `Copyright (c) YYYY Source Auditor Inc.` where `YYYY` is the first year that that file appears on the GitHub repo
- Add few missing Javadoc
- See also: https://github.com/spdx/Spdx-Java-Library/pull/291