### PR TITLE
Add a module name in the manifest file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.3.0</version>
+        <configuration>
+          <archive>
+              <manifestEntries>
+                  <Automatic-Module-Name>org.spdx.core</Automatic-Module-Name>
+              </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR adds a the Automatic-Module-Name manifest entry, making it easier for modular projects (Java 9 and above) to include this library.