### PR TITLE
Make 2 dashes equivalent to one

### DIFF
--- a/src/main/java/org/spdx/licenseTemplate/LicenseTextHelper.java
+++ b/src/main/java/org/spdx/licenseTemplate/LicenseTextHelper.java
@@ -34,7 +34,7 @@ public class LicenseTextHelper {
 	// most of these are comments for common programming languages (C style, Java, Ruby, Python)
 	protected static final Set<String> SKIPPABLE_TOKENS = Collections.unmodifiableSet(new HashSet<>(
 		Arrays.asList("//","/*","*/","/**","#","##","*","**","\"\"\"","/","=begin","=end")));
-	static final String DASHES_REGEX = "[\\u2012\\u2013\\u2014\\u2015]";
+	static final String DASHES_REGEX = "[\\u2012\\u2013\\u2014\\u2015\\-]{1,2}";
 	static final Pattern SPACE_PATTERN = Pattern.compile("[\\u202F\\u2007\\u2060\\u2009]");
 	static final Pattern COMMA_PATTERN = Pattern.compile("[\\uFF0C\\uFE10\\uFE50]");
 	static final Pattern PER_CENT_PATTERN = Pattern.compile("per cent", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/org/spdx/licenseTemplate/LicenseTextHelper.java
+++ b/src/main/java/org/spdx/licenseTemplate/LicenseTextHelper.java
@@ -34,7 +34,7 @@ public class LicenseTextHelper {
 	// most of these are comments for common programming languages (C style, Java, Ruby, Python)
 	protected static final Set<String> SKIPPABLE_TOKENS = Collections.unmodifiableSet(new HashSet<>(
 		Arrays.asList("//","/*","*/","/**","#","##","*","**","\"\"\"","/","=begin","=end")));
-	static final String DASHES_REGEX = "[\\u2012\\u2013\\u2014\\u2015\\-]{1,2}";
+	static final String DASHES_REGEX = "[\\u2010\\u2011\\u2012\\u2013\\u2014\\u2015\\uFE58\\uFF0D\\-]{1,2}";
 	static final Pattern SPACE_PATTERN = Pattern.compile("[\\u202F\\u2007\\u2060\\u2009]");
 	static final Pattern COMMA_PATTERN = Pattern.compile("[\\uFF0C\\uFE10\\uFE50]");
 	static final Pattern PER_CENT_PATTERN = Pattern.compile("per cent", Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
in the license matching algorithm

Implements proposed change to matching guidelines documented in https://github.com/spdx/license-list-XML/issues/2704#issuecomment-2814104932