### PR TITLE
Update dependencies in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>spdx-1</sonar.organization>
     <sonar.projectKey>spdx-java-core</sonar.projectKey>
-    <dependency-check-maven.version>8.0.1</dependency-check-maven.version>
+    <dependency-check-maven.version>8.0.2</dependency-check-maven.version>
   </properties>
   <profiles>  
     <profile>
@@ -57,7 +57,7 @@
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-slf4j2-impl</artifactId>
-          <version>2.20.0</version>
+          <version>2.25.1</version>
           <scope>test</scope>
           <exclusions>
             <exclusion>
@@ -89,7 +89,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.1.0</version>
+						<version>3.2.8</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -133,7 +133,7 @@
     <dependency>
     	<groupId>org.jsoup</groupId>
     	<artifactId>jsoup</artifactId>
-    	<version>1.15.4</version>
+    	<version>1.21.2</version>
     </dependency>
   </dependencies>
   <build>
@@ -174,7 +174,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>3.14.0</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
           <showDeprecation>true</showDeprecation>
@@ -185,7 +185,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
 			<id>add-source</id>
@@ -204,7 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.11.3</version>
         <configuration>
           <quiet>true</quiet>
           <notimestamp>true</notimestamp>
@@ -222,7 +222,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.2</version>
         <configuration>
           <archive>
               <manifestEntries>
@@ -248,7 +248,7 @@
       <plugin>
         <groupId>org.spdx</groupId>
         <artifactId>spdx-maven-plugin</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <executions>
           <execution>
             <id>build-spdx</id>


### PR DESCRIPTION
- Update to latest version of minor version
- Update spdx-maven-plugin to 1.0.3

Note that a new release of spdx-java-core is required in order to have a spdx-java-core that depends on commons-lang3 version without known security issue.
The new release spdx-java-core will then be used by the new releases of spdx-java-model-2_X, spdx-java-model-3_X, and later spdx-java-library.
See: https://github.com/spdx/Spdx-Java-Library/issues/345#issuecomment-3299286695