### PR TITLE
fix JavaDocs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,4 +29,4 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./target/site/apidocs
+        publish_dir: ./target/reports/apidocs


### PR DESCRIPTION
It looks like something changed where JavaDocs is now storing the results in the target/reports directory rather than the target/site directory.

This updates the docs workflow to point to the correct directory.